### PR TITLE
feat: access to own cache during recomputation

### DIFF
--- a/vendor/ember-cached-decorator-polyfill/index.js
+++ b/vendor/ember-cached-decorator-polyfill/index.js
@@ -34,9 +34,20 @@ import { assert } from '@ember/debug';
 
     const caches = new WeakMap();
     const getter = descriptor.get;
+
+    let isComputing = false;
+    let previousValue;
+
     descriptor.get = function () {
+      if (isComputing) return previousValue;
+
       if (!caches.has(this)) caches.set(this, createCache(getter.bind(this)));
-      return getValue(caches.get(this));
+
+      isComputing = true;
+      previousValue = getValue(caches.get(this));
+      isComputing = false;
+
+      return previousValue;
     };
   }
 


### PR DESCRIPTION
Crude implementation of https://github.com/emberjs/rfcs/pull/656#issuecomment-691698733.

This allows to access the previously cached value during the recomputation of a cache.


```ts
class {
  @tracked bidders = [];

  @cached
  get bidSources() {
    const {
      // Returns cached value or `undefined` on first computation.
      bidSources: previousBidSources = [], 
      bidders
    } = this; 

    // Generate a BidSource from each bidder, but avoid doing
    // it more than once per bidder.
    return bidders.map(bidder => {
      return previousBidSources.find(prev => prev.bidder === bidder) ||
        // expensive as it downloads initial state from server
        new BidSource(bidder);
    });
  }
}
```