### PR TITLE
Require 1.0.1 of cache primitive polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "test:ember-compatibility": "ember try:each"
   },
   "dependencies": {
-    "ember-cache-primitive-polyfill": "^1.0.0",
+    "ember-cache-primitive-polyfill": "^1.0.1",
     "ember-cli-babel": "^7.21.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Otherwise users may run into issues after upgrading past Ember 3.22.

https://github.com/ember-polyfills/ember-cache-primitive-polyfill/pull/71