### PR TITLE
Fix: check for hasPlugin needs the resolved path

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,9 +14,10 @@ module.exports = {
 
   addBabelPlugin() {
     let app = this._findHost();
+    let pluginPath = resolve(__dirname, './lib/transpile-modules.js');
 
-    if (!hasPlugin(app, 'ember-cache-decorator-polyfill')) {
-      addPlugin(app, resolve(__dirname, './lib/transpile-modules.js'));
+    if (!hasPlugin(app, pluginPath)) {
+      addPlugin(app, pluginPath);
     }
   }
 };


### PR DESCRIPTION
Confirmed this fix against a test addon and within ember-data

resolves #79 