### PR TITLE
fix: Allow the babel plugin to be registered for addons

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,18 +6,17 @@ const { hasPlugin, addPlugin } = require('ember-cli-babel-plugin-helpers');
 module.exports = {
   name: require('./package').name,
 
-  included() {
+  included(parent) {
     this._super.included.apply(this, arguments);
 
-    this.addBabelPlugin();
+    this.addBabelPlugin(parent);
   },
 
-  addBabelPlugin() {
-    let app = this._findHost();
+  addBabelPlugin(parent) {
     let pluginPath = resolve(__dirname, './lib/transpile-modules.js');
 
-    if (!hasPlugin(app, pluginPath)) {
-      addPlugin(app, pluginPath);
+    if (!hasPlugin(parent, pluginPath)) {
+      addPlugin(parent, pluginPath);
     }
   }
 };


### PR DESCRIPTION
### Description

This PR would fix the case when `@cached` is used in an addon.

When ember-cached-decorator-polyfill is used in an addon... Currently the babel polyfill is registered for the host app. So, adding the polyfill to the addon's package.json file doesn't allow the `@cached` transpilation to happen. 

This PR would allow the babel plugin to be registered for the addon instead.

### Links

If merged, this PR would make https://github.com/emberjs/data/pull/7599 possible.
It would fix https://github.com/concordnow/ember-aria-tabs/pull/218.
It might fix (I'm not sure) https://github.com/ember-polyfills/ember-cached-decorator-polyfill/pull/75#issuecomment-844912062.