### PR TITLE
Fix peerDependencies entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "configPath": "tests/dummy/config"
   },
   "peerDependencies": {
-    "ember-source": "^3.13.0 | ^4.0.0"
+    "ember-source": "^3.13.0 || ^4.0.0"
   },
   "release-it": {
     "plugins": {


### PR DESCRIPTION
Without this change, this error occurs:
```
test-app
└─┬ ember-cached-decorator-polyfill 0.1.4
  └── ✕ unmet peer ember-source@"^3.13.0 | ^4.0.0": found 4.7.0

```