### PR TITLE
Add ember-source v5 to peers list

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "configPath": "tests/dummy/config"
   },
   "peerDependencies": {
-    "ember-source": "^3.13.0 || ^4.0.0"
+    "ember-source": "^3.13.0 || ^4.0.0 || >= 5.0.0"
   },
   "release-it": {
     "plugins": {


### PR DESCRIPTION
This polyfill does nothing after 4.1, https://github.com/ember-polyfills/ember-cached-decorator-polyfill/blob/main/lib/transpile-modules.ts#L19

But folks may be using it for typescript reasons.
(esp if they aren't using the built-in types yet)

This PR eliminates a peer warning / violation from `@ember-data/model` in default app creation: 
```
├─┬ ember-data 5.0.0
│ └─┬ @ember-data/model 5.0.0
│   └─┬ ember-cached-decorator-polyfill 1.0.1
│     └── ✕ unmet peer ember-source@"^3.13.0 || ^4.0.0": found 5.0.0
```